### PR TITLE
Use better name to make it clear a routing key must be returned

### DIFF
--- a/doc/consumer.rst
+++ b/doc/consumer.rst
@@ -21,7 +21,7 @@ First of all, you have to create a PHP class which represents this message::
          */
         public $orderId;
 
-        public static function getName()
+        public static function getRoutingKey()
         {
             return 'order-created';
         }
@@ -45,7 +45,7 @@ With this message we are able to create our consumer which will send an email to
         }
 
         /**
-         * @Consumer(name="order-created")
+         * @Consumer(name="order-created-send-email")
          */
         public function sendMail(OrderCreatedMessage $message)
         {

--- a/src/Rebuy/Amqp/Consumer/Annotation/ConsumerContainer.php
+++ b/src/Rebuy/Amqp/Consumer/Annotation/ConsumerContainer.php
@@ -60,7 +60,7 @@ class ConsumerContainer
             return [];
         }
 
-        return [$this->getConsumerIdentification(), $this->getMessageName()];
+        return [$this->getConsumerIdentification(), $this->getRoutingKey()];
     }
 
     /**
@@ -68,17 +68,17 @@ class ConsumerContainer
      */
     public function getConsumerIdentification()
     {
-        return sprintf('%s-%s', $this->getConsumerName(), $this->getMessageName());
+        return sprintf('%s-%s', $this->getConsumerName(), $this->getRoutingKey());
     }
 
     /**
      * @return mixed
      */
-    public function getMessageName()
+    public function getRoutingKey()
     {
         $class = $this->method->getParameters()[0]->getClass();
 
-        return $class->getMethod('getName')->invoke(null);
+        return $class->getMethod('getRoutingKey')->invoke(null);
     }
 
     /**

--- a/src/Rebuy/Amqp/Consumer/Handler/RequeuerHandler.php
+++ b/src/Rebuy/Amqp/Consumer/Handler/RequeuerHandler.php
@@ -35,7 +35,7 @@ class RequeuerHandler implements ErrorHandlerInterface
         $nativeData = $table->getNativeData();
 
         if (!isset($nativeData['type'])) {
-            $table->set('type', $genericMessage->getName(), AMQPTable::T_STRING_LONG);
+            $table->set('type', $genericMessage->getRoutingKey(), AMQPTable::T_STRING_LONG);
         }
 
         if (!isset($nativeData['routing'])) {

--- a/src/Rebuy/Amqp/Consumer/Message/MessageInterface.php
+++ b/src/Rebuy/Amqp/Consumer/Message/MessageInterface.php
@@ -7,5 +7,5 @@ interface MessageInterface
     /**
      * @return string
      */
-    public static function getName();
+    public static function getRoutingKey();
 }

--- a/src/Rebuy/Amqp/Consumer/Subscriber/LogSubscriber.php
+++ b/src/Rebuy/Amqp/Consumer/Subscriber/LogSubscriber.php
@@ -40,7 +40,7 @@ class LogSubscriber implements EventSubscriberInterface
         $container = $event->getConsumerContainer();
         $message = sprintf(
             "Processing message [%s] for consumer [%s] with payload [%s]",
-            $container->getMessageName(),
+            $container->getRoutingKey(),
             $container->getMethodName(),
             $event->getMessage()->body
         );

--- a/tests/Rebuy/Tests/Amqp/Consumer/Stubs/Message.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Stubs/Message.php
@@ -6,7 +6,7 @@ use Rebuy\Amqp\Consumer\Message\MessageInterface;
 
 class Message implements MessageInterface
 {
-    public static function getName()
+    public static function getRoutingKey()
     {
         return 'genericMessage';
     }

--- a/tests/Rebuy/Tests/Amqp/Consumer/Subscriber/LogSubscriberTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Subscriber/LogSubscriberTest.php
@@ -37,8 +37,9 @@ class LogSubscriberTest extends \PHPUnit_Framework_TestCase
         $messageName = 'message-name';
         $methodName = 'MyClass::myMethod';
 
+        /** @var ConsumerContainer $consumerContainer */
         $consumerContainer = $this->prophesize(ConsumerContainer::class);
-        $consumerContainer->getMessageName()->willReturn($messageName);
+        $consumerContainer->getRoutingKey()->willReturn($messageName);
         $consumerContainer->getMethodName()->willReturn($methodName);
 
         $event = new ConsumerEvent(new AMQPMessage($body), $consumerContainer->reveal());


### PR DESCRIPTION
To make it clear that the message class must return a routing key, I changed the name of all desired methods.

/cc @rebuy-de/owners 