### PR TITLE
Update dependencies and fix non blocking value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 phpunit.xml
 vendor
 doc/_build/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,9 @@ cache:
 
 matrix:
     include:
-        - php: 5.6
-        - php: 5.6
+        - php: 7.2
+        - php: 7.2
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
-        - php: 7
-        - php: 7
-          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
-        - php: nightly
-        - php: hhvm
-    allow_failures:
-        - php: nightly
-        - php: hhvm
     fast_finish: true
 
 before_install: composer self-update

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "php-amqplib/php-amqplib": "~2.6",
         "doctrine/annotations": "~1.2",
         "symfony/event-dispatcher": "~3.0|~4.0",
@@ -20,8 +20,8 @@
     },
     "require-dev": {
         "jms/serializer": "~1.0",
-        "phpunit/phpunit": "~5.4",
-        "codeception/verify": "~0.3",
+        "phpunit/phpunit": "~8.1",
+        "codeception/verify": "~1.0",
         "league/statsd": "~1.1",
         "symfony/stopwatch": "~3.0|~4.0",
         "symfony/serializer": "~3.0|~4.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./tests/bootstrap.php"
         >
     <testsuites>

--- a/src/Rebuy/Amqp/Consumer/ConsumerManager.php
+++ b/src/Rebuy/Amqp/Consumer/ConsumerManager.php
@@ -82,7 +82,7 @@ class ConsumerManager
     public function wait()
     {
         while (count($this->channel->callbacks)) {
-            $this->channel->wait(null, true, $this->idleTimeout);
+            $this->channel->wait(null, false, $this->idleTimeout);
         }
     }
 

--- a/tests/Rebuy/Tests/Amqp/Consumer/Annotation/ConsumerContainerTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Annotation/ConsumerContainerTest.php
@@ -2,7 +2,7 @@
 
 namespace Rebuy\Tests\Amqp\Consumer\Annotation;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Rebuy\Amqp\Consumer\Annotation\Consumer as ConsumerAnnotation;
 use Rebuy\Amqp\Consumer\Annotation\ConsumerContainer;
 use Rebuy\Tests\Amqp\Consumer\Stubs\Consumer;
@@ -11,7 +11,7 @@ use Rebuy\Tests\Amqp\Consumer\Stubs\ConsumerWithTwoParameters;
 use Rebuy\Tests\Amqp\Consumer\Stubs\Message;
 use ReflectionMethod;
 
-class ConsumerContainerTest extends PHPUnit_Framework_TestCase
+class ConsumerContainerTest extends TestCase
 {
     const TEST_PREFIX = "test";
 

--- a/tests/Rebuy/Tests/Amqp/Consumer/Annotation/ParserTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Annotation/ParserTest.php
@@ -2,9 +2,10 @@
 
 namespace Rebuy\Tests\Amqp\Consumer\Annotation;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Rebuy\Amqp\Consumer\Annotation\Consumer as ConsumerAnnotation;
 use Rebuy\Amqp\Consumer\Annotation\Parser;
 use Rebuy\Tests\Amqp\Consumer\Stubs\Consumer;
@@ -14,7 +15,7 @@ use Rebuy\Tests\Amqp\Consumer\Stubs\ConsumerWithPrefetchCount;
 use Rebuy\Tests\Amqp\Consumer\Stubs\ConsumerWithTwoParameters;
 use Rebuy\Tests\Amqp\Consumer\Stubs\Message;
 
-class ParserTest extends PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     /**
      * @test
@@ -63,10 +64,11 @@ class ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
      */
     public function parser_should_not_parse_consumer_method_with_two_parameters()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $parser = new Parser(new AnnotationReader());
         $consumer = new ConsumerWithTwoParameters();
 
@@ -75,10 +77,11 @@ class ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
      */
     public function parser_should_not_parse_consumer_method_without_marker_interface()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $parser = new Parser(new AnnotationReader());
         $consumer = new ConsumerWithInvalidParameter();
 
@@ -87,10 +90,11 @@ class ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      */
     public function parser_should_throw_exception_when_name_for_consumer_is_not_set()
     {
+        $this->expectException(AnnotationException::class);
+
         $parser = new Parser(new AnnotationReader());
         $consumer = new ConsumerWithInvalidAnnotation();
 

--- a/tests/Rebuy/Tests/Amqp/Consumer/ConsumerManagerTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/ConsumerManagerTest.php
@@ -3,17 +3,18 @@
 namespace Rebuy\Tests\Amqp\Consumer;
 
 use PhpAmqpLib\Channel\AMQPChannel;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Rebuy\Amqp\Consumer\Annotation\ConsumerContainer;
 use Rebuy\Amqp\Consumer\Annotation\Parser;
 use Rebuy\Amqp\Consumer\ConsumerManager;
+use Rebuy\Amqp\Consumer\Exception\ConsumerException;
 use Rebuy\Amqp\Consumer\Serializer\Serializer;
 use stdClass;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ConsumerManagerTest extends PHPUnit_Framework_TestCase
+class ConsumerManagerTest extends TestCase
 {
     const EXCHANGE_NAME = 'exchange';
 
@@ -42,7 +43,7 @@ class ConsumerManagerTest extends PHPUnit_Framework_TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->channel = $this->prophesize(AMQPChannel::class);
         $this->serializer = $this->prophesize(Serializer::class);
@@ -60,21 +61,23 @@ class ConsumerManagerTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \Rebuy\Amqp\Consumer\Exception\ConsumerException
-     * @expectedExceptionMessage Expected argument of type "object", "string" given
      */
     public function register_consumer_with_string_parameter_should_throw_exception()
     {
+        $this->expectException(ConsumerException::class);
+        $this->expectExceptionMessage('Expected argument of type "object", "string" given');
+
         $this->manager->registerConsumer('string');
     }
 
     /**
      * @test
-     * @expectedException \Rebuy\Amqp\Consumer\Exception\ConsumerException
-     * @expectedExceptionMessage Expected argument of type "object", "integer" given
      */
     public function register_consumer_with_int_parameter_should_throw_exception()
     {
+        $this->expectException(ConsumerException::class);
+        $this->expectExceptionMessage('Expected argument of type "object", "integer" given');
+
         $this->manager->registerConsumer(12);
     }
 
@@ -98,10 +101,11 @@ class ConsumerManagerTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \Rebuy\Amqp\Consumer\Exception\ConsumerException
      */
     public function register_consumer_with_same_name_should_throw_exception()
     {
+        $this->expectException(ConsumerException::class);
+
         $container = $this->prophesize(ConsumerContainer::class);
         $container->getConsumerName()->willReturn('myName');
         $container->getMethodName()->willReturn('MyConsumer::method');

--- a/tests/Rebuy/Tests/Amqp/Consumer/Handler/LoggerHandlerTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Handler/LoggerHandlerTest.php
@@ -4,6 +4,7 @@ namespace Rebuy\Tests\Amqp\Consumer\Handler;
 
 use Exception;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
@@ -12,7 +13,7 @@ use Rebuy\Amqp\Consumer\Exception\ConsumerContainerException;
 use Rebuy\Amqp\Consumer\Handler\LogHandler;
 use Rebuy\Amqp\Consumer\Message\MessageInterface;
 
-class LoggerHandlerTest extends \PHPUnit_Framework_TestCase
+class LoggerHandlerTest extends TestCase
 {
     const MESSAGE_CLASS = 'MyClass';
 
@@ -31,7 +32,7 @@ class LoggerHandlerTest extends \PHPUnit_Framework_TestCase
      */
     private $consumerContainer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->handler = new LogHandler($this->logger->reveal());

--- a/tests/Rebuy/Tests/Amqp/Consumer/Handler/RequeuerHandlerTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Handler/RequeuerHandlerTest.php
@@ -5,6 +5,7 @@ namespace Rebuy\Tests\Amqp\Consumer\Handler;
 use Exception;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Rebuy\Amqp\Consumer\Annotation\ConsumerContainer;
@@ -13,7 +14,7 @@ use Rebuy\Amqp\Consumer\Exception\ConsumerContainerException;
 use Rebuy\Amqp\Consumer\Handler\RequeuerHandler;
 use Rebuy\Tests\Amqp\Consumer\Stubs\Message;
 
-class RequeuerHandlerTest extends \PHPUnit_Framework_TestCase
+class RequeuerHandlerTest extends TestCase
 {
     const CONSUMER_IDENTIFICATION = 'my-consumer-identification';
 
@@ -32,7 +33,7 @@ class RequeuerHandlerTest extends \PHPUnit_Framework_TestCase
      */
     private $handler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = $this->prophesize(ClientInterface::class);
         $this->handler = new RequeuerHandler($this->client->reveal());

--- a/tests/Rebuy/Tests/Amqp/Consumer/Subscriber/LogSubscriberTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Subscriber/LogSubscriberTest.php
@@ -3,6 +3,7 @@
 namespace Rebuy\Tests\Amqp\Consumer\Subscriber;
 
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
@@ -10,7 +11,7 @@ use Rebuy\Amqp\Consumer\Annotation\ConsumerContainer;
 use Rebuy\Amqp\Consumer\ConsumerEvent;
 use Rebuy\Amqp\Consumer\Subscriber\LogSubscriber;
 
-class LogSubscriberTest extends \PHPUnit_Framework_TestCase
+class LogSubscriberTest extends TestCase
 {
     /**
      * @var LoggerInterface|ObjectProphecy
@@ -22,7 +23,7 @@ class LogSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private $subscriber;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->subscriber = new LogSubscriber($this->logger->reveal());

--- a/tests/Rebuy/Tests/Amqp/Consumer/Subscriber/TimingSubscriberTest.php
+++ b/tests/Rebuy/Tests/Amqp/Consumer/Subscriber/TimingSubscriberTest.php
@@ -4,6 +4,7 @@ namespace Rebuy\Tests\Amqp\Consumer\Subscriber;
 
 use League\StatsD\Client;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Rebuy\Amqp\Consumer\Annotation\ConsumerContainer;
 use Rebuy\Amqp\Consumer\ConsumerEvent;
@@ -11,7 +12,7 @@ use Rebuy\Amqp\Consumer\Subscriber\TimingSubscriber;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
-class TimingSubscriberTest extends \PHPUnit_Framework_TestCase
+class TimingSubscriberTest extends TestCase
 {
     /**
      * @var Stopwatch|ObjectProphecy
@@ -28,7 +29,7 @@ class TimingSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private $subscriber;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->statsdClient = $this->prophesize(Client::class);
         $this->stopwatch = $this->prophesize(Stopwatch::class);


### PR DESCRIPTION
* Minimum php version is now PHP 7.2
* Updated to phpunit 8.x
* [This PR](https://github.com/php-amqplib/php-amqplib/pull/642/files#diff-195c265ed9a66166715118df34df6ea3R339) in the php-amqplib made it necessary to set the `non_blocking` parameter to `false`, which actually makes sense since we set a idle timeout (so it was wrong before but only is an issue since they fixed it in the lib)

/cc @bjoernhaeuser @dfreudenberger 