### PR TITLE
catch type errors thrown by consumers

### DIFF
--- a/src/Rebuy/Amqp/Consumer/ConsumerManager.php
+++ b/src/Rebuy/Amqp/Consumer/ConsumerManager.php
@@ -16,6 +16,7 @@ use Rebuy\Amqp\Consumer\Serializer\Serializer;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Throwable;
 
 class ConsumerManager
 {
@@ -202,7 +203,7 @@ class ConsumerManager
 
         try {
             $result = $consumerContainer->invoke($payload);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $containerException = new ConsumerContainerException($consumerContainer, $message, $payload, $e);
             if ($this->errorHandlers->isEmpty()) {
                 throw $containerException;

--- a/src/Rebuy/Amqp/Consumer/Exception/ConsumerContainerException.php
+++ b/src/Rebuy/Amqp/Consumer/Exception/ConsumerContainerException.php
@@ -7,6 +7,7 @@ use PhpAmqpLib\Message\AMQPMessage;
 use Rebuy\Amqp\Consumer\Annotation\ConsumerContainer;
 use Rebuy\Amqp\Consumer\Message\MessageInterface;
 use RuntimeException;
+use Throwable;
 
 class ConsumerContainerException extends RuntimeException
 {
@@ -29,13 +30,13 @@ class ConsumerContainerException extends RuntimeException
      * @param ConsumerContainer $consumerContainer
      * @param AMQPMessage $amqpMessage
      * @param MessageInterface $payloadMessage
-     * @param Exception $e
+     * @param Throwable $e
      */
     public function __construct(
         ConsumerContainer $consumerContainer,
         AMQPMessage $amqpMessage,
         MessageInterface $payloadMessage,
-        Exception $e
+        Throwable $e
     )
     {
         $this->payloadMessage = $payloadMessage;


### PR DESCRIPTION
If a type error occurs in one of the consumers the process keeps dying and can't continue processing other messages.