### PR TITLE
Remove polyfill replacements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,6 @@
         "friendsofphp/php-cs-fixer": "^3.95",
         "vimeo/psalm": "^6.16"
     },
-    "replace": {
-        "symfony/polyfill-php80": "*",
-        "symfony/polyfill-php81": "*",
-        "symfony/polyfill-php82": "*",
-        "symfony/polyfill-php83": "*",
-        "symfony/polyfill-php84": "*"
-    },
     "autoload": {
         "psr-4": {
             "Rebuy\\Amqp\\Consumer\\": "src/Rebuy/Amqp/Consumer"


### PR DESCRIPTION
Replacing polyfills can only be done at the root level `composer.json` as otherwise it will conflict with other replaces, thus removing it again.